### PR TITLE
UX: Adjust Avalanche Block Explorer to Snowscan

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,7 @@
             </div>
             <div class="contract-link">
               <div class="token-contact">
-                <a data-w-id="89101cb5-89bc-1954-9fe1-9d35e5c3d576" href="https://avascan.info/blockchain/all/address/0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553" target="_blank" class="link-block-5 w-inline-block">
+                <a data-w-id="89101cb5-89bc-1954-9fe1-9d35e5c3d576" href="https://snowscan.xyz/address/0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553" target="_blank" class="link-block-5 w-inline-block">
                   <div class="div-block-18">
                     <div class="line-1">
                       <div class="sm-stronger">Token Contract</div>


### PR DESCRIPTION
Just a very small change – changing the AVAX block explorer (link to the Frankencoin token) from:
https://avascan.info/blockchain/all/address/0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553
to 
https://snowscan.xyz/address/0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553

As you're using the Etherscan version of the block explorer on all other chains as well, this is simply a UX improvement.